### PR TITLE
Add access list pattern

### DIFF
--- a/contracts/BZDAccessList.sol
+++ b/contracts/BZDAccessList.sol
@@ -24,9 +24,8 @@ contract BZDAccessList {
     /// Events
     /// -----------------------------------------------------------------------
 
-    event ListCreated(address indexed operator, uint256 id);
-    event MerkleRootSet(uint256 id, bytes32 merkleRoot);
-    event AccountListed(address indexed account, uint256 id, bool approved);
+    // event ListCreated(address indexed operator, uint256 id);
+    // event AccountListed(address indexed account, uint256 id, bool approved);
 
     /// -----------------------------------------------------------------------
     /// Errors
@@ -130,19 +129,24 @@ contract BZDAccessList {
     }
 
     /// -----------------------------------------------------------------------
-    /// Verify Logic
+    /// Getter Logic
     /// -----------------------------------------------------------------------
 
     function verify(uint256 id, address account) external view returns (bool isListed) {
         return listed[id][account];
     }
 
-    /// -----------------------------------------------------------------------
-    /// Getter Logic
-    /// -----------------------------------------------------------------------
-
     function getList(uint256 id) external view returns (address[] memory, uint256) {
         return (lists[id], lists[id].length);
+    }
+
+    /// -----------------------------------------------------------------------
+    /// Admin Logic
+    /// -----------------------------------------------------------------------
+
+    function updateContract(IBZDMembershipDirectory _admins, IBZDMembershipNFT _nft) external onlyAdmin {
+        admins = _admins;
+        nft = _nft;
     }
 
     receive() external payable {}

--- a/contracts/BZDAccessList.sol
+++ b/contracts/BZDAccessList.sol
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.9;
+
+interface IBZDMembershipDirectory {
+    function isMember(address account) external view returns (bool);
+}
+
+interface IBZDMembershipNFT {
+    function mintAndAddMembersToSeason(address[] calldata members, uint256 seasonId) external ;
+}
+
+struct List {
+    uint256 fee;
+    address[] list;
+    mapping( address => bool) listed;
+}
+
+/// @title BZDWhitelist
+/// @notice BZD access manager
+/// credit: https://github.com/kalidao/kali-contracts/blob/main/contracts/access/KaliAccessManager.sol
+contract BZDAccessList {
+    /// -----------------------------------------------------------------------
+    /// Events
+    /// -----------------------------------------------------------------------
+
+    event ListCreated(address indexed operator, uint256 id);
+    event MerkleRootSet(uint256 id, bytes32 merkleRoot);
+    event AccountListed(address indexed account, uint256 id, bool approved);
+
+    /// -----------------------------------------------------------------------
+    /// Errors
+    /// -----------------------------------------------------------------------
+
+    error Unauthorized();
+    error IncorrectAmount();
+    error NotListed();
+    error NothingToRemove();
+
+    /// -----------------------------------------------------------------------
+    /// List Storage
+    /// -----------------------------------------------------------------------
+
+    // admins directory
+    IBZDMembershipDirectory public admins;
+    IBZDMembershipNFT public nft;
+
+    uint256 public listCount;
+    mapping(uint256 => address[]) lists;
+    mapping(uint256 => uint256) listMintFee;
+    mapping(uint256 => mapping(address => bool)) listed;
+
+    /**
+     * @dev Modifier to check that the caller is an admin.
+     */
+    modifier onlyAdmin() {
+        if (!admins.isMember(msg.sender)) revert Unauthorized();
+        _;
+    }
+
+    /// -----------------------------------------------------------------------
+    /// Constructor
+    /// -----------------------------------------------------------------------
+
+    constructor(IBZDMembershipDirectory _admins, IBZDMembershipNFT _nft) {
+        admins = _admins;
+        nft = _nft;
+    }
+
+    /// -----------------------------------------------------------------------
+    /// List Logic
+    /// -----------------------------------------------------------------------
+
+    function listAccount(address[] calldata accounts) external onlyAdmin {
+        unchecked {
+            ++listCount;
+        }
+
+        uint256 length = accounts.length;
+
+        for (uint256 i = 0; i < length; ) {
+
+            lists[listCount].push(accounts[i]);
+            listed[listCount][accounts[i]] = true;
+
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    function removeAccount(uint256 id, address account) external onlyAdmin {
+        if (lists[id].length < 1) revert NothingToRemove();
+
+        uint256 length = lists[id].length;
+        address accountToRemove;
+
+        for (uint256 i = 0; i < length; ) {
+
+            accountToRemove = lists[id][i];
+            
+            if (accountToRemove == account) {
+                lists[id][i] = address(0);
+                listed[id][account] = false;
+            }
+
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    function setMintPrice(uint256 id, uint256 fee) external onlyAdmin {
+        listMintFee[id] = fee;
+    }
+
+    /// -----------------------------------------------------------------------
+    /// Mint Logic
+    /// -----------------------------------------------------------------------
+
+    function mint(uint256 id, uint256 _seasonId) external payable {
+        if (!listed[id][msg.sender]) revert NotListed();
+        if (listMintFee[id] != msg.value) revert IncorrectAmount();
+
+        // Might look into creating a new function at BZDMembershipNFT to add single member
+        address[] memory _account = new address[](1);
+        _account[1] = msg.sender;
+
+        nft.mintAndAddMembersToSeason(_account, _seasonId);
+    }
+
+    /// -----------------------------------------------------------------------
+    /// Verify Logic
+    /// -----------------------------------------------------------------------
+
+    function verify(uint256 id, address account) external view returns (bool isListed) {
+        return listed[id][account];
+    }
+
+    /// -----------------------------------------------------------------------
+    /// Getter Logic
+    /// -----------------------------------------------------------------------
+
+    function getList(uint256 id) external view returns (address[] memory, uint256) {
+        return (lists[id], lists[id].length);
+    }
+
+    receive() external payable {}
+}

--- a/contracts/BZDAccessList.sol
+++ b/contracts/BZDAccessList.sol
@@ -2,56 +2,65 @@
 
 pragma solidity ^0.8.9;
 
+import "@openzeppelin/contracts/utils/Multicall.sol";
+
 interface IBZDMembershipDirectory {
     function isMember(address account) external view returns (bool);
 }
 
 interface IBZDMembershipNFT {
-    function mintAndAddMembersToSeason(address[] calldata members, uint256 seasonId) external ;
+    function mintAndAddMembersToSeason(address member, uint256 seasonId) external ;
 }
 
 struct List {
+    bool open;
     uint256 fee;
     address[] list;
-    mapping( address => bool) listed;
+    mapping(address => bool) listed;
 }
 
 /// @title BZDWhitelist
 /// @notice BZD access manager
 /// credit: https://github.com/kalidao/kali-contracts/blob/main/contracts/access/KaliAccessManager.sol
-contract BZDAccessList {
-    /// -----------------------------------------------------------------------
-    /// Events
-    /// -----------------------------------------------------------------------
-
-    // event ListCreated(address indexed operator, uint256 id);
-    // event AccountListed(address indexed account, uint256 id, bool approved);
-
+contract BZDAccessList is Multicall {
     /// -----------------------------------------------------------------------
     /// Errors
     /// -----------------------------------------------------------------------
 
     error Unauthorized();
+
     error IncorrectAmount();
+
+    error MintHasNotStarted();
+
     error NotListed();
-    error NothingToRemove();
 
+    error NoAccountToRemove();
+
+    error NoAccountToAdd();
+
+    error WithdrawalFailed();
+
+    error ListNotFound();
+    
     /// -----------------------------------------------------------------------
-    /// List Storage
+    /// Storage
     /// -----------------------------------------------------------------------
 
-    // admins directory
+    /// @dev BZDMembershipDirectory contract.
     IBZDMembershipDirectory public admins;
+    
+    /// @dev BZDMembershipNFT contract.
     IBZDMembershipNFT public nft;
 
     uint256 public listCount;
-    mapping(uint256 => address[]) lists;
-    mapping(uint256 => uint256) listMintFee;
-    mapping(uint256 => mapping(address => bool)) listed;
+    
+    mapping(uint256 => List) public lists;
 
-    /**
-     * @dev Modifier to check that the caller is an admin.
-     */
+    /// -----------------------------------------------------------------------
+    /// Modifier
+    /// -----------------------------------------------------------------------
+
     modifier onlyAdmin() {
         if (!admins.isMember(msg.sender)) revert Unauthorized();
         _;
@@ -70,7 +79,10 @@ contract BZDAccessList {
     /// List Logic
     /// -----------------------------------------------------------------------
 
-    function listAccount(address[] calldata accounts) external onlyAdmin {
+    /// @notice Add accounts.
+    /// @param accounts An array of accounts to add to an access list.
+    function list(address[] calldata accounts) external onlyAdmin {
+        if (accounts.length == 0) revert NoAccountToAdd();
         unchecked {
             ++listCount;
         }
@@ -79,8 +91,8 @@ contract BZDAccessList {
 
         for (uint256 i = 0; i < length; ) {
 
-            lists[listCount].push(accounts[i]);
-            listed[listCount][accounts[i]] = true;
+            lists[listCount].list.push(accounts[i]);
+            lists[listCount].listed[accounts[i]] = true;
 
             unchecked {
                 ++i;
@@ -88,19 +100,46 @@ contract BZDAccessList {
         }
     }
 
-    function removeAccount(uint256 id, address account) external onlyAdmin {
-        if (lists[id].length < 1) revert NothingToRemove();
+    /// @notice Add accounts to an existing list.
+    /// @param id The identifier of an existing list.
+    /// @param accounts An array of accounts to add to an existing access list.
+    function updateList(uint256 id, address[] calldata accounts) external onlyAdmin {
+        if (accounts.length == 0) revert NoAccountToAdd();
 
-        uint256 length = lists[id].length;
+        (, , , uint256 _length) = this.getList(id);
+
+        if (_length > 0) {
+            uint256 length = accounts.length;
+
+            for (uint256 i = 0; i < length; ) {
+
+                lists[id].list.push(accounts[i]);
+                lists[id].listed[accounts[i]] = true;
+
+                unchecked {
+                    ++i;
+                }
+            }
+        } else {
+            revert ListNotFound();
+        }
+    }
+
+    /// @notice Remove single account from an existing list.
+    /// @param id The identifier of an existing list.
+    /// @param account An account to be removed from an existing access list.
+    function remove(uint256 id, address account) external onlyAdmin {
+        (, , address[] memory _lists, uint256 _length ) = this.getList(id);
+        if (_length < 1) revert NoAccountToRemove();
+
         address accountToRemove;
 
-        for (uint256 i = 0; i < length; ) {
-
-            accountToRemove = lists[id][i];
+        for (uint256 i = 0; i < _length; ) {
+            accountToRemove = _lists[i];
             
             if (accountToRemove == account) {
-                lists[id][i] = address(0);
-                listed[id][account] = false;
+                delete lists[id].list[i];
+                delete lists[listCount].listed[accountToRemove];
             }
 
             unchecked {
@@ -109,44 +148,67 @@ contract BZDAccessList {
         }
     }
 
-    function setMintPrice(uint256 id, uint256 fee) external onlyAdmin {
-        listMintFee[id] = fee;
+    /// @notice Update mint price per access list.
+    /// @param id The identifier of an access list.
+    /// @param _fee The fee required to mint a BZDMembershipNFT.
+    function setMintPrice(uint256 id, uint256 _fee) external onlyAdmin {
+        lists[id].fee = _fee;
+    }
+
+    /// @notice Allow an access list to start minting BZDMembershipNFTs.
+    /// @param id The identifier of a list.
+    /// @param _open Status to mint a BZDMembershipNFT.
+    function startMint(uint256 id, bool _open) external onlyAdmin {
+        lists[id].open = _open;
     }
 
     /// -----------------------------------------------------------------------
     /// Mint Logic
     /// -----------------------------------------------------------------------
 
-    function mint(uint256 id, uint256 _seasonId) external payable {
-        if (!listed[id][msg.sender]) revert NotListed();
-        if (listMintFee[id] != msg.value) revert IncorrectAmount();
+    /// @notice Allow an access list to start minting BZDMembershipNFTs.
+    /// @param id The identifier of an access list.
+    /// @param seasonId The season to mint a BZDMembershipNFT.
+    function mint(uint256 id, uint256 seasonId) external payable {
+        (bool _open, uint256 _fee, ,) = this.getList(id);
+        (bool isListed) = this.verifyAccount(id, msg.sender);
 
-        // Might look into creating a new function at BZDMembershipNFT to add single member
-        address[] memory _account = new address[](1);
-        _account[1] = msg.sender;
+        if (!isListed) revert NotListed();
+        if (!_open) revert MintHasNotStarted();
+        if (_fee != msg.value) revert IncorrectAmount();
 
-        nft.mintAndAddMembersToSeason(_account, _seasonId);
+        nft.mintAndAddMembersToSeason(msg.sender, seasonId);
     }
 
     /// -----------------------------------------------------------------------
     /// Getter Logic
     /// -----------------------------------------------------------------------
 
-    function verify(uint256 id, address account) external view returns (bool isListed) {
-        return listed[id][account];
+    function verifyAccount(uint256 id, address account) external view returns (bool isListed) {
+        return lists[id].listed[account];
     }
 
-    function getList(uint256 id) external view returns (address[] memory, uint256) {
-        return (lists[id], lists[id].length);
+    function getList(uint256 id) external view returns (bool, uint256, address[] memory, uint256) {
+        return (lists[id].open, lists[id].fee, lists[id].list, lists[id].list.length);
     }
 
     /// -----------------------------------------------------------------------
     /// Admin Logic
     /// -----------------------------------------------------------------------
 
+    /// @notice Update contract addresses.
+    /// @param _admins The address of a BZDMembershipDirectory contract.
+    /// @param _nft The address of a BZDMembershipNFT contract.
     function updateContract(IBZDMembershipDirectory _admins, IBZDMembershipNFT _nft) external onlyAdmin {
         admins = _admins;
         nft = _nft;
+    }
+    
+    /// @notice Withraw funds from this BZDAccessList contract.
+    /// @param to The recipient to send funds to.
+    function withdraw(address payable to) external onlyAdmin {
+        (bool success, ) = to.call{value: address(this).balance}("");
+        if (!success) revert WithdrawalFailed();
     }
 
     receive() external payable {}

--- a/test/BZDAccessList.ts
+++ b/test/BZDAccessList.ts
@@ -1,0 +1,425 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import {
+  BZDAccessList,
+  BZDMembershipDirectory,
+  BZDMembershipNFTs,
+} from "../typechain";
+
+describe("BZDAccessList", function () {
+  let accessList: BZDAccessList;
+  let membershipDirectory: BZDMembershipDirectory;
+  let membershipNFTs: BZDMembershipNFTs;
+
+  let owner: SignerWithAddress,
+    addr1: SignerWithAddress,
+    addr2: SignerWithAddress,
+    nonOwner: SignerWithAddress;
+
+  beforeEach(async function () {
+    const accessListFactory = await ethers.getContractFactory("BZDAccessList");
+    const membershipDirectoryFactory = await ethers.getContractFactory(
+      "BZDMembershipDirectory"
+    );
+    const membershipNFTsFactory = await ethers.getContractFactory(
+      "BZDMembershipNFTs"
+    );
+
+    [owner, addr1, addr2, nonOwner] = await ethers.getSigners();
+
+    membershipDirectory =
+      (await membershipDirectoryFactory.deploy()) as BZDMembershipDirectory;
+    membershipNFTs =
+      (await membershipNFTsFactory.deploy()) as BZDMembershipNFTs;
+    accessList = (await accessListFactory.deploy(
+      membershipDirectory.address,
+      membershipNFTs.address
+    )) as BZDAccessList;
+
+    // Add admin
+    await membershipDirectory.addMember(addr1.address);
+
+    // Add accessList to membershipNFTs
+    await membershipNFTs.updateContract(accessList.address);
+  });
+
+  it("Should initialize with the correct params", async function () {
+    expect(await membershipDirectory.owner()).to.equal(owner.address);
+    expect(await membershipDirectory.isMember(addr1.address)).to.be.true;
+
+    expect(await accessList.nft()).to.equal(membershipNFTs.address);
+    expect(await accessList.admins()).to.equal(membershipDirectory.address);
+  });
+
+  it("Should allow admin to add accounts to access list", async function () {
+    await accessList
+      .connect(addr1)
+      .list([owner.address, addr1.address, addr2.address]);
+
+    let count = await accessList.listCount();
+    // console.log(count)
+    const [open, fee, list, listLength] = await accessList.getList(
+      accessList.listCount()
+    );
+
+    expect(list[0]).to.equal(owner.address);
+    expect(list[1]).to.equal(addr1.address);
+    expect(list[2]).to.equal(addr2.address);
+
+    expect(await accessList.verifyAccount(count, owner.address)).to.be.true;
+    expect(await accessList.verifyAccount(count, addr1.address)).to.be.true;
+    expect(await accessList.verifyAccount(count, addr2.address)).to.be.true;
+  });
+
+  it("Should not allow admin to add empty account array to access list", async function () {
+    expect(accessList
+      .connect(addr1)
+      .list([])).to.be.revertedWithCustomError(accessList, "NoAccountToAdd");
+  });
+
+  it("Should not allow non-admin to add accounts to access list", async function () {
+    expect(
+      accessList
+        .connect(addr2)
+        .list([owner.address, addr1.address, addr2.address])
+    ).to.be.revertedWithCustomError(accessList, "Unauthorized");
+  });
+
+  it("Should allow admin to update accounts to existing access list", async function () {
+    await accessList
+      .connect(addr1)
+      .list([owner.address, addr1.address, addr2.address]);
+
+    let count = await accessList.listCount();
+    const [, , list, listCount] = await accessList.getList(count);
+    // console.log("list", list, listCount);
+
+    expect(list[0]).to.equal(owner.address);
+    expect(list[1]).to.equal(addr1.address);
+    expect(list[2]).to.equal(addr2.address);
+
+    await accessList
+      .connect(addr1)
+      .updateList(count, [
+        nonOwner.address,
+        addr1.address,
+      ]);
+
+    const [, , updatedList, updatedListCount] = await accessList.getList(count);
+    // console.log("updatedList", updatedList, updatedListCount);
+    expect(updatedList[0]).to.equal(owner.address);
+    expect(updatedList[1]).to.equal(addr1.address);
+    expect(updatedList[2]).to.equal(addr2.address);
+    expect(updatedList[3]).to.equal(nonOwner.address);
+    expect(updatedList[4]).to.equal(addr1.address);
+    
+    expect(await accessList.verifyAccount(count, owner.address)).to.be.true;
+    expect(await accessList.verifyAccount(count, addr1.address)).to.be.true;
+    expect(await accessList.verifyAccount(count, addr2.address)).to.be.true;
+    expect(await accessList.verifyAccount(count, nonOwner.address)).to.be.true;
+  });
+
+  it("Should not allow admin to update accounts to an empty access list", async function () {
+    await expect(
+      accessList
+        .connect(addr1)
+        .updateList(1, [owner.address, addr1.address, addr2.address])
+    ).to.be.revertedWithCustomError(accessList, "ListNotFound");
+  });
+
+  it("Should not allow non-admin to update accounts", async function () {
+    await accessList
+      .connect(addr1)
+      .list([owner.address, addr1.address, addr2.address]);
+
+    const [, , list, ] = await accessList.getList(
+      accessList.listCount()
+    );
+
+    expect(list[0]).to.equal(owner.address);
+    expect(list[1]).to.equal(addr1.address);
+    expect(list[2]).to.equal(addr2.address);
+
+    await expect(
+      accessList
+        .connect(addr2)
+        .updateList(1, [owner.address, addr1.address, addr2.address])
+    ).to.be.revertedWithCustomError(accessList, "Unauthorized");
+  });
+
+  it("Should allow admin to update new contracts", async function () {
+    await accessList
+      .connect(addr1)
+      .updateContract(ethers.constants.AddressZero, ethers.constants.AddressZero);
+
+    expect(await accessList.admins()).to.equal(ethers.constants.AddressZero);
+    expect(await accessList.nft()).to.equal(ethers.constants.AddressZero);
+  });
+
+  it("Should not allow non-admin to add accounts to access list", async function () {
+    await expect(
+      accessList
+        .connect(addr2)
+        .updateContract(
+          ethers.constants.AddressZero,
+          ethers.constants.AddressZero
+        )
+    ).to.be.revertedWithCustomError(accessList, "Unauthorized");
+  });
+
+  it("Should allow admin to remove accounts from access list", async function () {
+    await accessList
+      .connect(addr1)
+      .list([owner.address, addr1.address, addr2.address]);
+
+    const [, , list] = await accessList.getList(accessList.listCount());
+
+    expect(list[0]).to.equal(owner.address);
+    expect(list[1]).to.equal(addr1.address);
+    expect(list[2]).to.equal(addr2.address);
+
+    await accessList
+      .connect(addr1)
+      .remove(accessList.listCount(), owner.address);
+
+    const [, , _list] = await accessList.getList(accessList.listCount());
+
+    expect(_list[0]).to.equal(ethers.constants.AddressZero);
+    expect(_list[1]).to.equal(addr1.address);
+    expect(_list[2]).to.equal(addr2.address);
+  });
+
+  // ADD ANOTHER TO INVOKE NoAccountToAdd();
+
+  it("Should not allow non-admin to remove accounts to access list", async function () {
+    await expect(
+      accessList.connect(addr2).remove(accessList.listCount(), owner.address)
+    ).to.be.revertedWithCustomError(accessList, "Unauthorized");
+  });
+
+  it("Should allow admin to set mint price", async function () {
+    await accessList.connect(addr1).setMintPrice(accessList.listCount(), 100);
+    const [, fee, ,] = await accessList.getList(accessList.listCount());
+    expect(fee).to.equal(100);
+  });
+
+  it("Should not allow non-admin to set mint price", async function () {
+    await expect(
+      accessList.connect(addr2).setMintPrice(accessList.listCount(), 100)
+    ).to.be.revertedWithCustomError(accessList, "Unauthorized");
+  });
+
+  it("Should allow admin to start mint", async function () {
+    await accessList.connect(addr1).startMint(accessList.listCount(), true);
+    const [open, , ,] = await accessList.getList(accessList.listCount());
+    expect(open).to.equal(true);
+  });
+
+  it("Should not allow non-admin to start mint", async function () {
+    await expect(
+      accessList.connect(addr2).startMint(accessList.listCount(), true)
+    ).to.be.revertedWithCustomError(accessList, "Unauthorized");
+  });
+
+  it("Should allow minting if on access list", async function () {
+    const seasonId = 1;
+    let count = await accessList.listCount();
+
+    await membershipNFTs.updateContract(accessList.address);
+
+    await accessList
+      .connect(addr1)
+      .list([owner.address, addr1.address, addr2.address]);
+    // console.log(count);
+
+    count = await accessList.listCount();
+    await accessList
+      .connect(addr1)
+      .setMintPrice(count, ethers.utils.parseEther("1"));
+    await accessList.connect(addr1).startMint(count, true);
+
+    // console.log(await membershipNFTs.balanceOf(addr2.address, seasonId));
+    const [, fee, list] = await accessList.getList(count);
+
+    expect(fee).to.equal(ethers.utils.parseEther("1"));
+    expect(list[1]).to.equal(addr1.address);
+
+    await accessList.connect(addr2).mint(count, seasonId, {
+      value: ethers.utils.parseEther("1"),
+    });
+    expect(await membershipNFTs.balanceOf(addr2.address, seasonId)).to.equal(1);
+  });
+
+  it("Should not allow minting if not on access list", async function () {
+    const seasonId = 1;
+    let count = await accessList.listCount();
+
+    await membershipNFTs.updateContract(accessList.address);
+
+    await accessList.connect(addr1).list([owner.address, addr1.address]);
+    // console.log(count);
+
+    count = await accessList.listCount();
+    await accessList
+      .connect(addr1)
+      .setMintPrice(count, ethers.utils.parseEther("1"));
+    await accessList.connect(addr1).startMint(count, true);
+
+    // console.log(await membershipNFTs.balanceOf(addr2.address, seasonId));
+    const [, fee, list] = await accessList.getList(count);
+
+    expect(fee).to.equal(ethers.utils.parseEther("1"));
+    expect(list[1]).to.equal(addr1.address);
+
+    await expect(
+      accessList.connect(addr2).mint(count, seasonId, {
+        value: ethers.utils.parseEther("1"),
+      })
+    ).to.revertedWithCustomError(accessList, "NotListed");
+  });
+
+  it("Should not allow minting if minting has not started", async function () {
+    const seasonId = 1;
+    let count = await accessList.listCount();
+
+    await membershipNFTs.updateContract(accessList.address);
+
+    await accessList
+      .connect(addr1)
+      .list([owner.address, addr1.address, addr2.address]);
+    // console.log(count);
+
+    count = await accessList.listCount();
+    await accessList
+      .connect(addr1)
+      .setMintPrice(count, ethers.utils.parseEther("1"));
+
+    const [, fee, list] = await accessList.getList(count);
+
+    expect(fee).to.equal(ethers.utils.parseEther("1"));
+    expect(list[1]).to.equal(addr1.address);
+
+    await expect(
+      accessList.connect(addr2).mint(count, seasonId, {
+        value: ethers.utils.parseEther("1"),
+      })
+    ).to.revertedWithCustomError(accessList, "MintHasNotStarted");
+  });
+
+  it("Should not allow double minting even if on access list", async function () {
+    const seasonId = 1;
+    let count = await accessList.listCount();
+
+    await membershipNFTs.updateContract(accessList.address);
+
+    await accessList
+      .connect(addr1)
+      .list([owner.address, addr1.address, addr2.address]);
+    // console.log(count);
+
+    count = await accessList.listCount();
+    await accessList
+      .connect(addr1)
+      .setMintPrice(count, ethers.utils.parseEther("1"));
+    await accessList.connect(addr1).startMint(count, true);
+
+    await accessList.connect(addr2).mint(count, seasonId, {
+      value: ethers.utils.parseEther("1"),
+    });
+    expect(await membershipNFTs.balanceOf(addr2.address, seasonId)).to.equal(1);
+
+    await expect(
+      accessList.connect(addr2).mint(count, seasonId, {
+        value: ethers.utils.parseEther("1"),
+      })
+    ).to.revertedWithCustomError(membershipNFTs, "ExistingMember");
+  });
+
+  it("Should not allow minting even if minting price unmatched", async function () {
+    const seasonId = 1;
+    let count = await accessList.listCount();
+
+    await membershipNFTs.updateContract(accessList.address);
+
+    await accessList
+      .connect(addr1)
+      .list([owner.address, addr1.address, addr2.address]);
+    // console.log(count);
+
+    count = await accessList.listCount();
+    await accessList
+      .connect(addr1)
+      .setMintPrice(count, ethers.utils.parseEther("1"));
+    await accessList.connect(addr1).startMint(count, true);
+
+    await expect(
+      accessList.connect(addr2).mint(count, seasonId, {
+        value: ethers.utils.parseEther("0.5"),
+      })
+    ).to.revertedWithCustomError(accessList, "IncorrectAmount");
+  });
+  
+  it("Should allow admin to withdraw from BZDAccessList", async function () {
+    const seasonId = 1;
+    let count = await accessList.listCount();
+
+    await membershipNFTs.updateContract(accessList.address);
+
+    await accessList
+      .connect(addr1)
+      .list([owner.address, addr1.address, addr2.address]);
+
+    count = await accessList.listCount();
+    await accessList
+      .connect(addr1)
+      .setMintPrice(count, ethers.utils.parseEther("1"));
+    await accessList.connect(addr1).startMint(count, true);
+
+    const [, fee, list] = await accessList.getList(count);
+    expect(fee).to.equal(ethers.utils.parseEther("1"));
+    expect(list[1]).to.equal(addr1.address);
+
+    await accessList.connect(addr2).mint(count, seasonId, {
+      value: ethers.utils.parseEther("1"),
+    });
+
+    let balance = await ethers.provider.getBalance(accessList.address);
+    expect(balance).to.equal(ethers.utils.parseEther("1"));
+    await accessList.connect(addr1).withdraw(nonOwner.address);
+    balance = await ethers.provider.getBalance(accessList.address);
+    expect(balance).to.equal(0);
+  });
+
+  it("Should not allow non-admin to withdraw from BZDAccessList", async function () {
+    const seasonId = 1;
+    let count = await accessList.listCount();
+
+    await membershipNFTs.updateContract(accessList.address);
+
+    await accessList
+      .connect(addr1)
+      .list([owner.address, addr1.address, addr2.address]);
+
+    count = await accessList.listCount();
+    await accessList
+      .connect(addr1)
+      .setMintPrice(count, ethers.utils.parseEther("1"));
+    await accessList.connect(addr1).startMint(count, true);
+
+    const [, fee, list] = await accessList.getList(count);
+    expect(fee).to.equal(ethers.utils.parseEther("1"));
+    expect(list[1]).to.equal(addr1.address);
+
+    await accessList.connect(addr2).mint(count, seasonId, {
+      value: ethers.utils.parseEther("1"),
+    });
+    
+    let balance = await ethers.provider.getBalance(accessList.address);
+    expect(balance).to.equal(ethers.utils.parseEther("1"));
+    await expect(accessList.connect(addr2).withdraw(nonOwner.address)).to.be.revertedWithCustomError(accessList, "Unauthorized");
+
+    balance = await ethers.provider.getBalance(accessList.address);
+    expect(balance).to.equal(ethers.utils.parseEther("1"));
+  });
+});

--- a/test/BZDMembershipNFTs.ts
+++ b/test/BZDMembershipNFTs.ts
@@ -80,7 +80,7 @@ describe("BZDMembershipNFTs", () => {
     const members = [addr1.address, addr2.address];
     const seasonId = 1;
 
-    await contract.mintAndAddMembersToSeason(members, seasonId);
+    await contract.mintAndAddMembersToSeasonByAdmin(members, seasonId);
 
     // Check if the membership NFTs were minted
     expect(await contract.balanceOf(addr1.address, seasonId)).to.equal(1);
@@ -97,7 +97,9 @@ describe("BZDMembershipNFTs", () => {
     const seasonId = 1;
 
     expect(
-      contract.connect(addr1).mintAndAddMembersToSeason(members, seasonId)
+      contract
+        .connect(addr1)
+        .mintAndAddMembersToSeasonByAdmin(members, seasonId)
     ).to.be.revertedWithCustomError(contract, "Unauthorized");
   });
 
@@ -107,7 +109,7 @@ describe("BZDMembershipNFTs", () => {
     const seasonId = 2;
 
     expect(
-      contract.mintAndAddMembersToSeason(members, seasonId)
+      contract.mintAndAddMembersToSeasonByAdmin(members, seasonId)
     ).to.be.revertedWithCustomError(contract, "Unauthorized");
   });
 
@@ -117,7 +119,7 @@ describe("BZDMembershipNFTs", () => {
     const seasonId = 1;
 
     // Mint NFTs and add members to the season
-    await contract.mintAndAddMembersToSeason(members, seasonId);
+    await contract.mintAndAddMembersToSeasonByAdmin(members, seasonId);
 
     // Burn NFTs and remove members from the season
     await contract.burnAndRemoveMemberFromSeason(addr1.address, seasonId);
@@ -138,7 +140,7 @@ describe("BZDMembershipNFTs", () => {
     const seasonId = 1;
 
     // Mint NFTs and add members to the season
-    await contract.mintAndAddMembersToSeason(members, seasonId);
+    await contract.mintAndAddMembersToSeasonByAdmin(members, seasonId);
 
     expect(
       contract
@@ -163,7 +165,7 @@ describe("BZDMembershipNFTs", () => {
     const seasonId = 1;
 
     // Mint NFTs and add members to the season
-    await contract.mintAndAddMembersToSeason(members, seasonId);
+    await contract.mintAndAddMembersToSeasonByAdmin(members, seasonId);
 
     await expect(
       contract
@@ -178,7 +180,7 @@ describe("BZDMembershipNFTs", () => {
     const seasonId = 1;
 
     // Mint NFTs and add members to the season
-    await contract.mintAndAddMembersToSeason(members, seasonId);
+    await contract.mintAndAddMembersToSeasonByAdmin(members, seasonId);
 
     await expect(
       contract
@@ -226,7 +228,7 @@ describe("BZDMembershipNFTs", () => {
 
     // Mint NFTs for new season
     const members = [addr1.address, addr3.address];
-    await contract.mintAndAddMembersToSeason(members, newSeason);
+    await contract.mintAndAddMembersToSeasonByAdmin(members, newSeason);
 
     const memberDirectoryAddress = await contract.membersBySeason(newSeason);
     const memberDirectory = await ethers.getContractAt(


### PR DESCRIPTION
- Added `BZDAccessList` and its test file
- Updated `BZDMembershipNFTs` to allow access list minting  
     -  Added `mintAndAddMembersToSeasonByAdmin` for admins to add new members
     - Updated `mintAndAddMembersToSeason` for access list accounts to pay and mint membershipNFT
     - Updated test file accordingly
- Add `name` and `symbol` to  `BZDMembershipNFTs`

cc @taipeicityeth 